### PR TITLE
MapEditor: Add "Delete shape" section

### DIFF
--- a/interface-elements-for-desktop/articles/map/map-editor.md
+++ b/interface-elements-for-desktop/articles/map/map-editor.md
@@ -31,7 +31,7 @@ The Map editor provides the following modes that define the available actions wh
 
 ### Default Mode
 
-You can only view the map in Default mode. You can use the ![Default Mode Button](../../images/map-editor-default-mode-button.png) button to turn on this mode. 
+You can view the map in Default mode. You can delete a shape, by [selecting](selection.md) it and pressing the **Del** key. You can use the ![Default Mode Button](../../images/map-editor-default-mode-button.png) button to turn on this mode. 
 
 ### Transform Mode
 


### PR DESCRIPTION
The map editor misses a description of the deletion of a shape. This PR adds such a description.